### PR TITLE
security: remove debug logs and centralise API base URL in env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Base URL for the WordPress backend API.
+# Used for GraphQL queries and REST endpoints (subscribe, popular posts).
+# PUBLIC_ prefix makes it available in client-side scripts as well as server-side.
+PUBLIC_API_BASE_URL=https://blog.djmixoftheweek.com

--- a/src/components/addComment.astro
+++ b/src/components/addComment.astro
@@ -54,7 +54,7 @@ const messageColor = "black";
           const email = form.querySelector('#email')?.value;
           const commentText = form.querySelector('#commentText')?.value;
 
-          const response = await fetch('https://blog.djmixoftheweek.com/graphql', {
+          const response = await fetch(`${import.meta.env.PUBLIC_API_BASE_URL}/graphql`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({

--- a/src/components/comments.astro
+++ b/src/components/comments.astro
@@ -59,7 +59,7 @@ const { threadedComments, postId } = Astro.props as Props;
 
       const postId = form?.getAttribute('data-post-id');
 
-      const response = await fetch('https://blog.djmixoftheweek.com/graphql', {
+      const response = await fetch(`${import.meta.env.PUBLIC_API_BASE_URL}/graphql`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/components/footer/footer.astro
+++ b/src/components/footer/footer.astro
@@ -33,9 +33,7 @@ import './footer.css';
       const name = (document.getElementById('footer-name') as HTMLInputElement).value;
       const email = (document.getElementById('footer-email') as HTMLInputElement).value;
 
-      console.log(11, 'Form submitted:', { name, email });
-
-      const res = await fetch('https://blog.djmixoftheweek.com/wp-json/custom/v1/subscribe', {
+      const res = await fetch(`${import.meta.env.PUBLIC_API_BASE_URL}/wp-json/custom/v1/subscribe`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/components/header/header.astro
+++ b/src/components/header/header.astro
@@ -10,7 +10,7 @@ import Search from '../search/search.astro';
 let popularPosts: PopularPost[] = [];
 
 try {
-  const response = await fetch('https://blog.djmixoftheweek.com/wp-json/top-10/v1/popular-posts');
+  const response = await fetch(`${import.meta.env.PUBLIC_API_BASE_URL}/wp-json/top-10/v1/popular-posts`);
   if (!response.ok) throw new Error(`Failed to fetch: ${response.status}`);
   popularPosts = await response.json();
 } catch (error) {
@@ -100,9 +100,7 @@ const decodeHtmlEntities = (text: string) => {
       const name = (document.getElementById('name') as HTMLInputElement).value;
       const email = (document.getElementById('email') as HTMLInputElement).value;
 
-      console.log(10, 'Form submitted:', { name, email });
-
-      const res = await fetch('https://blog.djmixoftheweek.com/wp-json/custom/v1/subscribe', {
+      const res = await fetch(`${import.meta.env.PUBLIC_API_BASE_URL}/wp-json/custom/v1/subscribe`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/components/search/search.astro
+++ b/src/components/search/search.astro
@@ -28,7 +28,7 @@
         async handleSearch() {
           this.searchPerformed = false;
           try {
-            const GRAPHQL_ENDPOINT = 'https://blog.djmixoftheweek.com/graphql';
+            const GRAPHQL_ENDPOINT = `${import.meta.env.PUBLIC_API_BASE_URL}/graphql`;
             const SEARCH_QUERY = `
             query SearchPosts($search: String!) {
               posts(where: { search: $search }, first: 4) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,5 @@
 export async function fetchGraphQL(query: string, variables = {}) {
-	const response = await fetch("https://blog.djmixoftheweek.com/graphql", {
+	const response = await fetch(`${import.meta.env.PUBLIC_API_BASE_URL}/graphql`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({ query, variables }),

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -12,7 +12,7 @@ if (!slug) {
   return Astro.redirect('/404');
 }
 
-const singleResponse = await fetch('https://blog.djmixoftheweek.com/graphql', {
+const singleResponse = await fetch(`${import.meta.env.PUBLIC_API_BASE_URL}/graphql`, {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({

--- a/src/pages/sitemap.xml.js
+++ b/src/pages/sitemap.xml.js
@@ -2,7 +2,7 @@ export async function GET() {
   const siteUrl = "https://djmixoftheweek.com";
 
   // Fetch all posts from your WordPress API
-  const response = await fetch("https://blog.djmixoftheweek.com/graphql", {
+  const response = await fetch(`${import.meta.env.PUBLIC_API_BASE_URL}/graphql`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({


### PR DESCRIPTION
## What changed and why

### Fix 3 — Remove debug logs leaking user data
Two `console.log` statements were logging users' submitted name and email to the browser console in production. Removed from:
- `src/components/header/header.astro` (line 103)
- `src/components/footer/footer.astro` (line 36)

### Fix 4 — Centralise hardcoded API base URL
`https://blog.djmixoftheweek.com` was hardcoded in 9 separate files. Any environment change (staging, local dev) required manually updating every file. All occurrences are now replaced with `import.meta.env.PUBLIC_API_BASE_URL`.

**Files updated:** `src/lib/api.ts`, `src/components/header/header.astro`, `src/components/footer/footer.astro`, `src/components/search/search.astro`, `src/components/comments.astro`, `src/components/addComment.astro`, `src/pages/[...slug].astro`, `src/pages/sitemap.xml.js`

**New file:** `.env.example` documents the required variable.

## Action required before merging

Add the following to your `.env` file (create it if it does not exist):
```
PUBLIC_API_BASE_URL=https://blog.djmixoftheweek.com
```

Also add `PUBLIC_API_BASE_URL` as an environment variable in your Vercel project settings with the same value, otherwise the production build will fail.

## Test plan

- [ ] Add `PUBLIC_API_BASE_URL=https://blog.djmixoftheweek.com` to `.env`
- [ ] Run `npm run dev` — homepage, search, post pages, and comments should all load data correctly
- [ ] Submit the subscribe form in header and footer — confirm no `console.log` output appears in the browser console
- [ ] Submit a comment on a post — confirm it posts successfully
- [ ] Run `npm run build` — confirm build completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)