### PR TITLE
security: add HTTP security headers and fix placeholder fallback images

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -38,7 +38,7 @@ import { SEO } from "astro-seo";
         basic: {
           title: pageTitle || 'DJ Mix Of The Week',
           type: 'Article',
-          image: opengraphImage || 'https://example.com/default-image.jpg',
+          image: opengraphImage || `${Astro.site}blog-placeholder-1.jpg`,
         },
         optional: {
           description:

--- a/src/pages/DJ/[...slug].astro
+++ b/src/pages/DJ/[...slug].astro
@@ -5,7 +5,7 @@ import '../../styles/post.css';
 import GET_ALL_DJS from '../../lib/queries/getAllDJs';
 import type { DJ, Post } from '../../types';
 
-const fallbackImage = 'https://example.com/default-image.jpg';
+const fallbackImage = '/blog-placeholder-1.jpg';
 
 const { slug } = Astro.params;
 

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -4,7 +4,7 @@ import '../styles/post.css';
 import Comments from '../components/comments.astro';
 import type { Comments as CommentsType } from '../types';
 
-const fallbackImage = 'https://example.com/default-image.jpg';
+const fallbackImage = '/blog-placeholder-1.jpg';
 
 const { slug } = Astro.params;
 

--- a/src/pages/genre/[...slug].astro
+++ b/src/pages/genre/[...slug].astro
@@ -7,7 +7,7 @@ import "../../styles/post.css";
 import GET_ALL_GENRES from "../../lib/queries/getAllGenres";
 import type { Genre, Post } from "../../types";
 
-const fallbackImage = "https://example.com/default-image.jpg";
+const fallbackImage = '/blog-placeholder-1.jpg';
 
 const { slug } = Astro.params;
 

--- a/src/pages/nationality/[...slug].astro
+++ b/src/pages/nationality/[...slug].astro
@@ -5,7 +5,7 @@ import '../../styles/post.css';
 import GET_ALL_NATIONALITIES from '../../lib/queries/getAllNationalities';
 import type { Nationality, Post } from '../../types';
 
-const fallbackImage = 'https://example.com/default-image.jpg';
+const fallbackImage = '/blog-placeholder-1.jpg';
 
 const { slug } = Astro.params;
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,29 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        },
+        {
+          "key": "Content-Security-Policy-Report-Only",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com https://partner.googleadservices.com https://tpc.googlesyndication.com https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://blog.djmixoftheweek.com https://*.googlesyndication.com https://googleads.g.doubleclick.net https://*.gstatic.com; connect-src 'self' https://blog.djmixoftheweek.com https://www.google-analytics.com https://analytics.google.com https://vitals.vercel-insights.com; font-src 'self'; frame-src https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://w.soundcloud.com https://www.mixcloud.com; worker-src 'self'; object-src 'none'"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What changed and why

### Fix 6 — HTTP security headers (`vercel.json`)

No security headers were previously configured. Added via a new `vercel.json` applied to all routes (`/(.*)`):

| Header | Value | Purpose |
|--------|-------|---------|
| `X-Frame-Options` | `SAMEORIGIN` | Prevents the site being embedded in iframes on other origins (clickjacking protection) |
| `X-Content-Type-Options` | `nosniff` | Stops browsers guessing MIME types, preventing content-sniffing attacks |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Sends full referrer for same-origin requests, only origin for cross-origin — no path/query leakage |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Explicitly disables browser APIs the site does not use |
| `Content-Security-Policy-Report-Only` | _(see below)_ | Logs CSP violations without blocking anything — allows observation before enforcement |

The CSP is set to **report-only** (not enforced) because AdSense, GTM, Partytown, and Vercel Analytics each require specific allowlists that need to be validated against real traffic before enforcement. Once violations are reviewed and the policy confirmed, change `Content-Security-Policy-Report-Only` to `Content-Security-Policy`.

### Fix 7 — Replace placeholder fallback images

Five files used `https://example.com/default-image.jpg` as a fallback — a URL that does not exist and would result in broken images. Replaced with `/blog-placeholder-1.jpg` which already exists in `/public`.

The Open Graph fallback in `BaseLayout.astro` uses `${Astro.site}blog-placeholder-1.jpg` to produce the absolute URL that OG tags require.

**Files updated:** `src/pages/[...slug].astro`, `src/pages/genre/[...slug].astro`, `src/pages/nationality/[...slug].astro`, `src/pages/DJ/[...slug].astro`, `src/layouts/BaseLayout.astro`

### Fix 5 — CSRF (not implemented — backend required)

CSRF protection on the subscribe and comment forms requires server-side token generation and validation in WordPress. This cannot be implemented from the static frontend alone. Recommended next step: add nonce-based CSRF tokens to the WP REST API endpoints (`/wp-json/custom/v1/subscribe`) and to the GraphQL comment mutation handler.

## Action required before merging

None — `vercel.json` is picked up automatically by Vercel on deploy.

## Test plan

- [ ] Deploy to Vercel (or preview) and inspect response headers with browser DevTools or `curl -I https://djmixoftheweek.com` — confirm all four new headers are present
- [ ] Check the browser console for CSP report-only violations after browsing homepage, a post page, and triggering search/AdSense — review and note any violations for future CSP enforcement
- [ ] Visit a post page, genre page, DJ page, and nationality page that have no featured image — confirm `/blog-placeholder-1.jpg` renders instead of a broken image
- [ ] Confirm OG image tag on a page without an explicit image shows the placeholder (use `og:debugger` or view source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)