### PR TITLE
perf: prerender static pages via output: static

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,12 @@
       "Bash(git add:*)",
       "Bash(git commit -m ':*)",
       "Bash(git push:*)",
-      "Bash(gh pr:*)"
+      "Bash(gh pr:*)",
+      "Bash(du *)",
+      "Bash(file *)",
+      "Bash(yarn build *)",
+      "Bash(git commit *)",
+      "Bash(npx ttf2woff2 *)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ pnpm-debug.log*
 
 .vercel
 .claude/settings.local.json
+.claude/settings.local.json

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,7 +12,7 @@ const siteUrl = isProduction
 	: "http://localhost:4321";
 
 export default defineConfig({
-	output: "server",
+	output: "static",
 	adapter: vercel({
 		webAnalytics: { enabled: true },
 	}),

--- a/src/pages/DJ/[...slug].astro
+++ b/src/pages/DJ/[...slug].astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = false;
+
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { fetchGraphQL } from '../../lib/api';
 import '../../styles/post.css';

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = false;
+
 import BaseLayout from '../layouts/BaseLayout.astro';
 import '../styles/post.css';
 import Comments from '../components/comments.astro';

--- a/src/pages/genre/[...slug].astro
+++ b/src/pages/genre/[...slug].astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = false;
+
 import { Image } from "astro:assets";
 
 import BaseLayout from "../../layouts/BaseLayout.astro";

--- a/src/pages/nationality/[...slug].astro
+++ b/src/pages/nationality/[...slug].astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = false;
+
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { fetchGraphQL } from '../../lib/api';
 import '../../styles/post.css';


### PR DESCRIPTION
## Summary

- Switches `astro.config.mjs` from `output: \"server\"` to `output: \"static\"` (the current Astro equivalent of the old `hybrid` mode)
- Static pages (`/`, `/about`, `/genres`, `/league-of-mixes`, `/404`) are now prerendered at build time and served from Vercel's CDN edge cache — no server invocation needed on each request
- Dynamic slug pages (`/[...slug]`, `/DJ/[...slug]`, `/genre/[...slug]`, `/nationality/[...slug]`) retain on-demand SSR via `export const prerender = false`

## Why

Previously every page, including fully static ones like the homepage, triggered a Vercel serverless function on every request. Prerendering those pages eliminates that overhead and serves them at the edge, which directly improves TTFB and LCP scores.

## Test plan

- [ ] Build passes (`yarn build`) ✅
- [ ] Homepage loads and shows posts correctly
- [ ] About, genres, league-of-mixes pages load correctly
- [ ] Individual post pages (`/[slug]`) still load correctly (SSR)
- [ ] Genre, DJ, nationality pages still load correctly (SSR)
- [ ] 404 page renders for unknown routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)