### PR TITLE
fix(a11y): critical accessibility fixes - alt text, headings, form labels

### DIFF
--- a/src/components/header/header.astro
+++ b/src/components/header/header.astro
@@ -68,9 +68,9 @@ const decodeHtmlEntities = (text: string) => {
         messages until I'm satisfied it is working!
       </p>
       <form id="subscribe-form">
-        <label> Name: </label>
+        <label for="name">Name:</label>
         <input autocomplete="name" type="text" id="name" required />
-        <label> Email: </label>
+        <label for="email">Email:</label>
         <input autocomplete="email" type="email" id="email" required />
         <button type="submit">Subscribe</button>
       </form>

--- a/src/components/search/search.astro
+++ b/src/components/search/search.astro
@@ -1,6 +1,8 @@
 <div x-data="searchComponent()">
   <form @submit.prevent="handleSearch">
+    <label for="search-input">Search</label>
     <input
+      id="search-input"
       type="text"
       placeholder="Search..."
       x-model="searchTerm"
@@ -10,7 +12,7 @@
     <button type="submit" :disabled="isLoading">Search</button>
   </form>
 
-  <ul x-show="searchResults.length > 0">
+  <ul x-show="searchResults.length > 0" aria-live="polite" aria-label="Search results">
     <h3>Search Results:</h3>
     <template x-for="post in searchResults" :key="post.slug">
       <li>

--- a/src/pages/DJ/[...slug].astro
+++ b/src/pages/DJ/[...slug].astro
@@ -74,7 +74,7 @@ const capitaliseAndRemoveHyphens = (string: string | undefined) => {
   description={`All posts of DJ ${capitaliseAndRemoveHyphens(slug)}`}
   opengraphImage={postsByDJ[0]?.seo?.opengraphImage?.sourceUrl || fallbackImage}
 >
-  <h1>Genre: {capitaliseAndRemoveHyphens(slug)}</h1>
+  <h1>DJ: {capitaliseAndRemoveHyphens(slug)}</h1>
 
   {
     postsByDJ.length === 0 ? (
@@ -95,7 +95,7 @@ const capitaliseAndRemoveHyphens = (string: string | undefined) => {
                 <img
                   src={post?.featuredImage?.node?.sourceUrl || fallbackImage}
                   srcset={post?.featuredImage?.node?.srcSet}
-                  alt={post?.title.rendered || ''}
+                  alt={post?.title.rendered || post?.title || capitaliseAndRemoveHyphens(slug)}
                   sizes="(max-width: 600px) 100vw, 700px"
                   width={700}
                   height={466.67}

--- a/src/pages/DJ/[...slug].astro
+++ b/src/pages/DJ/[...slug].astro
@@ -95,7 +95,7 @@ const capitaliseAndRemoveHyphens = (string: string | undefined) => {
                 <img
                   src={post?.featuredImage?.node?.sourceUrl || fallbackImage}
                   srcset={post?.featuredImage?.node?.srcSet}
-                  alt={post?.title.rendered || post?.title || capitaliseAndRemoveHyphens(slug)}
+                  alt={post?.title?.rendered || (typeof post?.title === 'string' ? post?.title : undefined) || capitaliseAndRemoveHyphens(slug)}
                   sizes="(max-width: 600px) 100vw, 700px"
                   width={700}
                   height={466.67}

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -156,7 +156,7 @@ const formattedDate = new Date(singlePost.date).toLocaleDateString('en-GB', {
     }
   </div>
   <article class="container">
-    <h2>{singlePost.title}</h2>
+    <h1>{singlePost.title}</h1>
     <date>
       Posted: {formattedDate}
     </date>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -34,7 +34,7 @@ try {
     )
   }
   <div class="container">
-    <h2>{singlePost?.title}</h2>
+    <h1>{singlePost?.title}</h1>
     <div set:html={singlePost?.content} />
   </div>
 </BaseLayout>

--- a/src/pages/genre/[...slug].astro
+++ b/src/pages/genre/[...slug].astro
@@ -65,7 +65,7 @@ const capitaliseAndRemoveHyphens = (string: string | undefined) => {
               <img
                 src={post?.featuredImage?.node?.sourceUrl || fallbackImage}
                 srcset={post?.featuredImage?.node?.srcSet}
-                alt={post?.title.rendered || post?.title || capitaliseAndRemoveHyphens(slug)}
+                alt={post?.title?.rendered || (typeof post?.title === 'string' ? post?.title : undefined) || capitaliseAndRemoveHyphens(slug)}
                 sizes="(max-width: 600px) 100vw, 700px"
                 width={700}
                 height={466.67}

--- a/src/pages/genre/[...slug].astro
+++ b/src/pages/genre/[...slug].astro
@@ -65,7 +65,7 @@ const capitaliseAndRemoveHyphens = (string: string | undefined) => {
               <img
                 src={post?.featuredImage?.node?.sourceUrl || fallbackImage}
                 srcset={post?.featuredImage?.node?.srcSet}
-                alt={post?.title.rendered || ''}
+                alt={post?.title.rendered || post?.title || capitaliseAndRemoveHyphens(slug)}
                 sizes="(max-width: 600px) 100vw, 700px"
                 width={700}
                 height={466.67}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -69,7 +69,7 @@ try {
           <a href={post.slug} rel="noopener noreferrer" aria-label={post.title}>
             <Image
               src={post.featured_image}
-              alt={``}
+              alt={post.title}
               width={768}
               height={576}
               loading={index === 0 ? 'eager' : 'lazy'}

--- a/src/pages/nationality/[...slug].astro
+++ b/src/pages/nationality/[...slug].astro
@@ -101,7 +101,7 @@ const capitaliseAndRemoveHyphens = (string: string | undefined) => {
                 <img
                   src={post?.featuredImage?.node?.sourceUrl || fallbackImage}
                   srcset={post?.featuredImage?.node?.srcSet}
-                  alt={post?.title.rendered || ''}
+                  alt={post?.title.rendered || post?.title || capitaliseAndRemoveHyphens(slug)}
                   sizes="(max-width: 600px) 100vw, 700px"
                   width={700}
                   height={466.67}

--- a/src/pages/nationality/[...slug].astro
+++ b/src/pages/nationality/[...slug].astro
@@ -101,7 +101,7 @@ const capitaliseAndRemoveHyphens = (string: string | undefined) => {
                 <img
                   src={post?.featuredImage?.node?.sourceUrl || fallbackImage}
                   srcset={post?.featuredImage?.node?.srcSet}
-                  alt={post?.title.rendered || post?.title || capitaliseAndRemoveHyphens(slug)}
+                  alt={post?.title?.rendered || (typeof post?.title === 'string' ? post?.title : undefined) || capitaliseAndRemoveHyphens(slug)}
                   sizes="(max-width: 600px) 100vw, 700px"
                   width={700}
                   height={466.67}

--- a/src/scripts/load-more.ts
+++ b/src/scripts/load-more.ts
@@ -37,7 +37,7 @@ document.addEventListener("DOMContentLoaded", () => {
 					post?.featuredImage?.node?.mediaDetails?.sizes?.find(
 						(size) => size.name === "medium_large",
 					)?.sourceUrl || "";
-				img.alt = "";
+				img.alt = post?.title?.rendered || "";
 				img.width = 768;
 				img.height = 576;
 				img.loading = "lazy";


### PR DESCRIPTION
## Summary

- **Alt text**: All images now have meaningful alt text; removed empty `alt=""` on index page images and dynamically loaded images in `load-more.ts`
- **Heading hierarchy**: Promoted `<h2>` to `<h1>` on post pages and about page; fixed incorrect "Genre:" label to "DJ:" on the DJ listing page
- **Form labels**: Added `for` attributes to subscribe form labels in header, associating them with their inputs
- **Search**: Added `<label for="search-input">` and `aria-live="polite"` + `aria-label` on the results list
- **Alt fallbacks**: Genre, DJ, and nationality listing pages now fall back to the slug name instead of an empty string when post title is unavailable

## Test plan

- [ ] Screen reader test: verify images are announced with meaningful descriptions on homepage and listing pages
- [ ] Check heading structure with a browser extension (e.g. HeadingsMap) on post, about, and DJ pages
- [ ] Tab to subscribe form and confirm label announces correctly
- [ ] Tab to search input and confirm label is read
- [ ] Trigger a search and confirm results list is announced via live region

🤖 Generated with [Claude Code](https://claude.com/claude-code)