### PR TITLE
fix(a11y): ARIA live regions, skip link, and keyboard focus improvements

### DIFF
--- a/src/components/comment.astro
+++ b/src/components/comment.astro
@@ -56,7 +56,7 @@ const formatDate = (dateString: string): string => {
   </p>
   <Fragment set:html={comment.content} />
 
-  <button class="reply-btn" data-target-id={comment.id}> Reply </button>
+  <button class="reply-btn" data-target-id={comment.id} aria-label={`Reply to ${comment.author.node.name}`}> Reply </button>
 
   <div class="reply-form-container" id={`reply-form-${comment.id}`} style="display: none;">
     <AddComment postId={postId} parentId={comment.id} />

--- a/src/components/comments.astro
+++ b/src/components/comments.astro
@@ -40,7 +40,7 @@ const { threadedComments, postId } = Astro.props as Props;
       <textarea id="commentText" required></textarea>
     </div>
     <button type="submit">Post Comment</button>
-    <p id="message"></p>
+    <p id="message" role="status" aria-live="polite" aria-atomic="true"></p>
   </form>
 </section>
 

--- a/src/components/footer/footer.astro
+++ b/src/components/footer/footer.astro
@@ -19,7 +19,7 @@ import './footer.css';
       <input autocomplete="email" type="email" id="footer-email" required />
       <button type="submit">Subscribe</button>
     </form>
-    <p class="response" id="footer-response-message"></p>
+    <p class="response" id="footer-response-message" role="status" aria-live="polite" aria-atomic="true"></p>
   </section>
   <Search />
   <p>DJ Mix Of The Week</p>

--- a/src/components/header/header.astro
+++ b/src/components/header/header.astro
@@ -74,7 +74,7 @@ const decodeHtmlEntities = (text: string) => {
         <input autocomplete="email" type="email" id="email" required />
         <button type="submit">Subscribe</button>
       </form>
-      <p class="response" id="response-message"></p>
+      <p class="response" id="response-message" role="status" aria-live="polite" aria-atomic="true"></p>
     </section>
   </div>
 
@@ -83,12 +83,16 @@ const decodeHtmlEntities = (text: string) => {
     const navMenu = document.getElementById('nav-menu') as HTMLElement;
 
     navToggle.addEventListener('click', function () {
+      const isOpen = !!navMenu.style.maxHeight;
       this.classList.toggle('open');
 
-      if (navMenu.style.maxHeight) {
+      if (isOpen) {
         navMenu.style.maxHeight = '';
+        navToggle.focus();
       } else {
         navMenu.style.maxHeight = navMenu.scrollHeight + 'px';
+        const firstLink = navMenu.querySelector<HTMLElement>('a, button');
+        firstLink?.focus();
       }
     });
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -68,9 +68,10 @@ import { SEO } from "astro-seo";
 </script>
   </head>
   <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="page-container">
       <Header />
-      <main>
+      <main id="main-content">
         <slot />
       </main>
     </div>

--- a/src/layouts/layout.css
+++ b/src/layouts/layout.css
@@ -4,6 +4,22 @@
 	--text: #333;
 }
 
+.skip-link {
+	position: absolute;
+	top: -100%;
+	left: 0;
+	background: var(--menu);
+	color: var(--white);
+	padding: 0.5rem 1rem;
+	z-index: 9999;
+	text-decoration: none;
+	font-weight: bold;
+}
+
+.skip-link:focus {
+	top: 0;
+}
+
 * {
 	margin: 0;
 	padding: 0;

--- a/src/scripts/load-more.ts
+++ b/src/scripts/load-more.ts
@@ -16,6 +16,8 @@ document.addEventListener("DOMContentLoaded", () => {
 		}
 
 		button.textContent = "Loading...";
+		button.setAttribute("aria-busy", "true");
+		button.disabled = true;
 
 		try {
 			const response = await fetchGraphQL(MORE_POSTS, { first, after: cursor });
@@ -67,6 +69,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
 			button.dataset.cursor = cursor || "";
 			button.textContent = "Load More";
+			button.removeAttribute("aria-busy");
+			button.disabled = false;
 
 			if (!cursor) {
 				button.style.display = "none";
@@ -74,6 +78,8 @@ document.addEventListener("DOMContentLoaded", () => {
 		} catch (error) {
 			console.error("Error loading more posts:", error);
 			button.textContent = "Load More";
+			button.removeAttribute("aria-busy");
+			button.disabled = false;
 		}
 	});
 });


### PR DESCRIPTION
## Summary

- **Skip link**: Added a visually hidden skip-to-main-content link in `BaseLayout.astro` that becomes visible on focus, letting keyboard users bypass the nav
- **Live regions**: Added `role="status"`, `aria-live="polite"`, and `aria-atomic="true"` to all form response `<p>` elements (header subscribe, footer subscribe, comments) so screen readers announce success/error messages
- **Load More button**: Added `aria-busy="true"` and `disabled` during fetch; both are cleared on success or error so screen readers and keyboard users know when the button is active again
- **Reply buttons**: Added `aria-label="Reply to {author name}"` so screen readers give each button a unique, meaningful name
- **Mobile nav focus**: When the nav opens, focus moves to the first link; when it closes, focus returns to the toggle button

## Test plan

- [ ] Tab to the page — skip link should appear on first focus and jump to `#main-content`
- [ ] Submit subscribe form (header and footer) — confirm screen reader announces the response message
- [ ] Submit a comment — confirm response message is announced
- [ ] Click Load More — button should be disabled while loading and re-enabled after
- [ ] On mobile, open/close nav with keyboard — confirm focus moves appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)