### PR TITLE
fix(a11y): focus-visible styles, figcaption size, and body color fix

### DIFF
--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -180,6 +180,16 @@
 	}
 }
 
+#nav-menu a:focus-visible {
+	outline: 2px solid var(--white);
+	outline-offset: 2px;
+}
+
+#nav-toggle:focus-visible {
+	outline: 2px solid var(--white);
+	outline-offset: 4px;
+}
+
 .open ~ #nav-menu {
 	visibility: visible;
 	max-height: 500px;

--- a/src/layouts/layout.css
+++ b/src/layouts/layout.css
@@ -103,7 +103,7 @@ body {
 	margin: 0;
 	padding: 0;
 	box-sizing: border-box;
-	color: blue;
+	color: var(--text);
 	font-size: 18px;
 	height: 100%;
 	min-height: 100%;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -44,6 +44,11 @@ ul {
 	a {
 		text-decoration: none;
 		color: var(--color-text);
+
+		&:focus-visible {
+			outline: 2px solid var(--menu);
+			outline-offset: 2px;
+		}
 	}
 
 	h2 {

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -7,7 +7,7 @@
 		left: 0;
 		background-color: rgba(0, 0, 0, 0.5);
 		color: white;
-		font-size: 0.625rem;
+		font-size: 0.75rem;
 		width: 100%;
 
 		@media (min-width: 835px) {


### PR DESCRIPTION
## Summary

- **Focus indicators**: Added `:focus-visible` outlines to nav links, the nav toggle button, and post list links — keyboard users now get a clear visible focus ring on all interactive elements
- **Body color**: Removed `color: blue` from `body` in `layout.css` (was likely a leftover debug value); replaced with `color: var(--text)` (#333)
- **Figcaption readability**: Increased minimum figcaption font-size from `0.625rem` (10px) to `0.75rem` (12px) on mobile — still scales up at larger breakpoints

## Test plan

- [ ] Tab through the nav — each link and the toggle button should show a white outline on focus
- [ ] Tab through the post list — each post link should show a purple outline on focus
- [ ] Check body text colour is dark grey (not blue) on any page
- [ ] Check figcaptions on post/genre/DJ/nationality pages are legible on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)