### PR TITLE
Make genre tags on homepage clickable links

### DIFF
--- a/src/lib/queries/morePosts.ts
+++ b/src/lib/queries/morePosts.ts
@@ -20,6 +20,7 @@ const MORE_POSTS = `
         genres {
           nodes {
             name
+            slug
           }
         }
       }

--- a/src/lib/queries/mostRecentPost.ts
+++ b/src/lib/queries/mostRecentPost.ts
@@ -18,6 +18,7 @@ const MOST_RECENT_POST_QUERY = `
         genres {
           nodes {
             name
+            slug
           }
         }
       }

--- a/src/lib/queries/otherPostsAfterFirst.ts
+++ b/src/lib/queries/otherPostsAfterFirst.ts
@@ -19,6 +19,7 @@ const OTHER_POSTS_AFTER_FIRST_QUERY = `
         genres {
           nodes {
             name
+            slug
           }
         }
       }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -84,7 +84,14 @@ const FALLBACK_IMAGE = '/blog-placeholder-1.jpg';
             </h2>
           </a>
           <ul class="genres">
-            <li>{post.genres.nodes.map((genre) => genre?.name).join(', ')}</li>
+            <li>
+              {post.genres.nodes.map((genre, i) => (
+                <span>
+                  <a href={`/genre/${genre.slug}`} rel="noopener noreferrer">{genre.name}</a>
+                  {i < post.genres.nodes.length - 1 && ', '}
+                </span>
+              ))}
+            </li>
           </ul>
         </li>
       ))

--- a/src/scripts/load-more.ts
+++ b/src/scripts/load-more.ts
@@ -55,8 +55,16 @@ document.addEventListener("DOMContentLoaded", () => {
 				const ul = document.createElement("ul");
 				ul.className = "genres";
 				const genreLi = document.createElement("li");
-				genreLi.textContent =
-					post?.genres.nodes.map((genre) => genre.name).join(", ") || "";
+				post?.genres.nodes.forEach((genre, i) => {
+					const a = document.createElement("a");
+					a.href = `/genre/${genre.slug}`;
+					a.rel = "noopener noreferrer";
+					a.textContent = genre.name;
+					genreLi.appendChild(a);
+					if (i < (post?.genres.nodes.length ?? 0) - 1) {
+						genreLi.appendChild(document.createTextNode(", "));
+					}
+				});
 				ul.appendChild(genreLi);
 
 				li.appendChild(imgLink);


### PR DESCRIPTION
## Summary

- Add `slug` to `genres.nodes` in `mostRecentPost`, `otherPostsAfterFirst`, and `morePosts` GraphQL queries
- Render each genre tag as `<a href="/genre/{slug}">` in `src/pages/index.astro`, replacing the plain `.join(', ')` text
- Update `src/scripts/load-more.ts` to build linked genre tags for dynamically loaded posts

Closes #271

## Test plan

- [ ] Homepage genre labels are now links — clicking one navigates to `/genre/{slug}`
- [ ] Load-more posts also render genre links, not plain text
- [ ] Genre links open the correct genre browse page
- [ ] No regressions on genre/DJ/nationality browse pages (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)