### PR TITLE
feat: add Share This Mix button to individual mix pages

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -164,6 +164,14 @@ const formattedDate = new Date(singlePost.date).toLocaleDateString('en-GB', {
     <div set:html={singlePost.soundcloud.soundcloud} />
     <br />
     <div set:html={singlePost.mixcloud.mixcloud} />
+    <div class="share-container" x-data="{ copied: false }">
+      <button
+        class="share-button"
+        @click="navigator.clipboard.writeText(window.location.href).then(() => { copied = true; setTimeout(() => copied = false, 2000) })"
+        :class="{ 'share-button--copied': copied }"
+        x-text="copied ? 'Copied!' : 'Share This Mix'"
+      ></button>
+    </div>
     <Comments threadedComments={threadedComments} postId={singlePost.postId} />
   </article>
 </BaseLayout>

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -83,6 +83,31 @@ article {
 	}
 }
 
+.share-container {
+	display: flex;
+	justify-content: center;
+	margin: 1.5rem 0;
+}
+
+.share-button {
+	background-color: var(--text);
+	border: none;
+	border-radius: 0.25rem;
+	color: var(--white);
+	cursor: pointer;
+	font-size: 1rem;
+	padding: 0.5rem 1.25rem;
+	transition: background-color 0.2s ease;
+
+	&:hover {
+		opacity: 0.85;
+	}
+
+	&.share-button--copied {
+		background-color: #2a9d4e;
+	}
+}
+
 .genres-list {
 	padding: 0;
 	text-align: center;


### PR DESCRIPTION
Adds a clipboard copy button below the mix embeds that copies the current page URL and shows a brief Copied! confirmation, leveraging existing Alpine.js and CSS variables.

Closes #273